### PR TITLE
Tolerate consecutive failures

### DIFF
--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -117,9 +117,9 @@ const monitor = async () => {
       consecutiveFlakes = 0
       console.log("Health check passed.")
     } catch (e) {
-      console.log("Unknown error: " + e + ". Paging.")
-
       consecutiveFlakes++
+
+      console.log("Unknown error: " + e + ". Consecutive flakes is now: " + consecutiveFlakes)
       if (consecutiveFlakes >= ACCEPTABLE_CONSECUTIVE_FLAKES) {
         page("Unknown error", e.message, 5 * 60, e.message)
       }

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -40,6 +40,8 @@ const ACCEPTABLE_CONSECUTIVE_FLAKES = 3
 
 /** End Config */
 
+let version = "0.0.2"
+
 const HEADERS = { "headers": { "Content-Type": "application/json" } };
 
 const pagerDutyClient = new PagerDuty(PAGER_DUTY_API_KEY);
@@ -49,6 +51,8 @@ let consecutiveMisses = 0
 let consecutiveFlakes = 0
 
 const monitor = async () => {
+  console.log("Starting Oasis Health Monitor v" + version)
+
   while (true) {
     console.log("Running Health Check!")
 

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -125,6 +125,7 @@ const monitor = async () => {
 
       console.log("Unknown error: " + e + ". Consecutive flakes is now: " + consecutiveFlakes)
       if (consecutiveFlakes >= ACCEPTABLE_CONSECUTIVE_FLAKES) {
+        console.log("Threshold exceeded. Paging.")
         page("Unknown error", e.message, 5 * 60, e.message)
       }
     }


### PR DESCRIPTION
Sometimes the Oasis API flakes and drops calls.